### PR TITLE
Allow for grade calculation to still be used when sorting

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 // @name        Canvas Grade Calculator
 // @description Calculate grade totals for Canvas courses that have it disabled.
 // @namespace   https://github.com/uncenter/canvas-grade-calculator
-// @match       https://*.instructure.com/courses/*/grades
+// @match       https://*.instructure.com/courses/*/grades*
 // @grant       GM_registerMenuCommand
 // @downloadURL https://github.com/uncenter/canvas-grade-calculator/raw/main/index.js
 // @homepageURL https://github.com/uncenter/canvas-grade-calculator


### PR DESCRIPTION
For example, the tool doesn't work if you're sorting on the grading tab and the URL is something like`https://*.instructure.com/courses/3236/*?grading_period_id=229`. By adding a * at the end this can be easily fixed